### PR TITLE
no crash for unlogged users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
 end

--- a/app/controllers/islands_controller.rb
+++ b/app/controllers/islands_controller.rb
@@ -1,5 +1,6 @@
 class IslandsController < ApplicationController
   before_action :find_island, only: %i[edit destroy]
+  skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
     if params[:query].present?

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: :home
   def home
   end
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,13 +1,13 @@
 class Booking < ApplicationRecord
-  before_create :set_total_price
+  before_create :cal_total_price
   belongs_to :user
   belongs_to :island
 
   validates :start_date, presence: true
   validates :end_date, presence: true
 
-  def set_total_price
+  def cal_total_price
     duration = (end_date - start_date).to_i
-    total_price = duration * island.price_per_day
+    duration * island.price_per_day
   end
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -14,7 +14,7 @@
   <p>start date: <%= received_booking.start_date %></p>
   <p>end date: <%= received_booking.end_date %></p>
   <p>comment: <%= received_booking.comment %></p>
-  <p>total price: <%= received_booking.total_price %></p>
+  <p>total price: <%= received_booking.cal_total_price %> $</p>
   <% if received_booking.status == 'pending' %>
     <%= button_to 'accept', booking_path(received_booking, {status: 'accepted'}), method: :patch %>
     <%= button_to 'decline', booking_path(received_booking, {status: 'declined'}), method: :patch %>
@@ -30,7 +30,7 @@
 <% @applied_bookings.each do |applied_booking| %>
   <p>start date: <%= applied_booking.start_date %></p>
   <p>end date: <%= applied_booking.end_date %></p>
-  <p>total price: <%= applied_booking.total_price %></p>
+  <p>total price: <%= applied_booking.cal_total_price %> $</p>
   <p>status: <%= applied_booking.status %></p>
 <% end %>
 


### PR DESCRIPTION
when unlogged user try to do actions that require him to be logged, instead of site crash it will redirect him to be logged in
an unlogged user can do the following: 
-view the home page
-search the index of all islands
-view a specific island

an unlogged user can't do the following:
-create a new island
-deleting a new island
- go on the dashboard
- book an island